### PR TITLE
Comment fix: ConcatVstackHstackPad uses a 2 by 2 matrix instead of 3 by 5

### DIFF
--- a/nd4j-examples/src/main/java/org/nd4j/examples/ConcatVstackHstackPad.java
+++ b/nd4j-examples/src/main/java/org/nd4j/examples/ConcatVstackHstackPad.java
@@ -23,7 +23,7 @@ public class ConcatVstackHstackPad {
         the different ways to create INDArrays, and more operations we can do on them.
          */
 
-        //Let's start by creating a basic 2d array: a matrix with 3 rows and 5 columns. All elements are 0.0
+        //Let's start by creating a basic 2d array: a matrix with 2 rows and 2 columns. All elements are 0.0
         int nRows = 2;
         int nColumns = 2;
         INDArray zeros = Nd4j.zeros(nRows, nColumns);


### PR DESCRIPTION
Issue #758

## What changes were proposed in this pull request?

Change the comment that says the ConcatVstackHstackPad.java uses a 3 by 5 matrix, when it uses a 2 by 2 matrix.

## How was this patch tested?

--

Please review
https://github.com/deeplearning4j/deeplearning4j/blob/master/CONTRIBUTING.md before opening a pull request.