### PR TITLE
Update project and app gradle files for android

### DIFF
--- a/android/DL4JImageRecognitionDemo/app/build.gradle
+++ b/android/DL4JImageRecognitionDemo/app/build.gradle
@@ -64,33 +64,33 @@ android {
         implementation 'com.android.support:appcompat-v7:27.1.0'
         implementation 'com.android.support:design:27.1.0'
 
-        compile (group: 'org.deeplearning4j', name: 'deeplearning4j-core', version: '1.0.0-beta5') {
+        implementation (group: 'org.deeplearning4j', name: 'deeplearning4j-core', version: '1.0.0-beta5') {
             exclude group: 'org.bytedeco', module: 'opencv-platform'
             exclude group: 'org.bytedeco', module: 'leptonica-platform'
             exclude group: 'org.bytedeco', module: 'hdf5-platform'
             exclude group: 'org.nd4j', module: 'nd4j-base64'
         }
 
-        compile group: 'org.nd4j', name: 'nd4j-native', version: '1.0.0-beta5'
-        compile group: 'org.nd4j', name: 'nd4j-native', version: '1.0.0-beta5', classifier: "android-arm"
-        compile group: 'org.nd4j', name: 'nd4j-native', version: '1.0.0-beta5', classifier: "android-arm64"
-        compile group: 'org.nd4j', name: 'nd4j-native', version: '1.0.0-beta5', classifier: "android-x86"
-        compile group: 'org.nd4j', name: 'nd4j-native', version: '1.0.0-beta5', classifier: "android-x86_64"
-        compile group: 'org.bytedeco', name: 'openblas', version: '0.3.5-1.5'
-        compile group: 'org.bytedeco', name: 'openblas', version: '0.3.5-1.5', classifier: "android-arm"
-        compile group: 'org.bytedeco', name: 'openblas', version: '0.3.5-1.5', classifier: "android-arm64"
-        compile group: 'org.bytedeco', name: 'openblas', version: '0.3.5-1.5', classifier: "android-x86"
-        compile group: 'org.bytedeco', name: 'openblas', version: '0.3.5-1.5', classifier: "android-x86_64"
-        compile group: 'org.bytedeco', name: 'opencv', version: '4.0.1-1.5'
-        compile group: 'org.bytedeco', name: 'opencv', version: '4.0.1-1.5', classifier: "android-arm"
-        compile group: 'org.bytedeco', name: 'opencv', version: '4.0.1-1.5', classifier: "android-arm64"
-        compile group: 'org.bytedeco', name: 'opencv', version: '4.0.1-1.5', classifier: "android-x86"
-        compile group: 'org.bytedeco', name: 'opencv', version: '4.0.1-1.5', classifier: "android-x86_64"
-        compile group: 'org.bytedeco', name: 'leptonica', version: '1.78.0-1.5'
-        compile group: 'org.bytedeco', name: 'leptonica', version: '1.78.0-1.5', classifier: "android-arm"
-        compile group: 'org.bytedeco', name: 'leptonica', version: '1.78.0-1.5', classifier: "android-arm64"
-        compile group: 'org.bytedeco', name: 'leptonica', version: '1.78.0-1.5', classifier: "android-x86"
-        compile group: 'org.bytedeco', name: 'leptonica', version: '1.78.0-1.5', classifier: "android-x86_64"
+        implementation group: 'org.nd4j', name: 'nd4j-native', version: '1.0.0-beta5'
+        implementation group: 'org.nd4j', name: 'nd4j-native', version: '1.0.0-beta5', classifier: "android-arm"
+        implementation group: 'org.nd4j', name: 'nd4j-native', version: '1.0.0-beta5', classifier: "android-arm64"
+        implementation group: 'org.nd4j', name: 'nd4j-native', version: '1.0.0-beta5', classifier: "android-x86"
+        implementation group: 'org.nd4j', name: 'nd4j-native', version: '1.0.0-beta5', classifier: "android-x86_64"
+        implementation group: 'org.bytedeco', name: 'openblas', version: '0.3.5-1.5'
+        implementation group: 'org.bytedeco', name: 'openblas', version: '0.3.5-1.5', classifier: "android-arm"
+        implementation group: 'org.bytedeco', name: 'openblas', version: '0.3.5-1.5', classifier: "android-arm64"
+        implementation group: 'org.bytedeco', name: 'openblas', version: '0.3.5-1.5', classifier: "android-x86"
+        implementation group: 'org.bytedeco', name: 'openblas', version: '0.3.5-1.5', classifier: "android-x86_64"
+        implementation group: 'org.bytedeco', name: 'opencv', version: '4.0.1-1.5'
+        implementation group: 'org.bytedeco', name: 'opencv', version: '4.0.1-1.5', classifier: "android-arm"
+        implementation group: 'org.bytedeco', name: 'opencv', version: '4.0.1-1.5', classifier: "android-arm64"
+        implementation group: 'org.bytedeco', name: 'opencv', version: '4.0.1-1.5', classifier: "android-x86"
+        implementation group: 'org.bytedeco', name: 'opencv', version: '4.0.1-1.5', classifier: "android-x86_64"
+        implementation group: 'org.bytedeco', name: 'leptonica', version: '1.78.0-1.5'
+        implementation group: 'org.bytedeco', name: 'leptonica', version: '1.78.0-1.5', classifier: "android-arm"
+        implementation group: 'org.bytedeco', name: 'leptonica', version: '1.78.0-1.5', classifier: "android-arm64"
+        implementation group: 'org.bytedeco', name: 'leptonica', version: '1.78.0-1.5', classifier: "android-x86"
+        implementation group: 'org.bytedeco', name: 'leptonica', version: '1.78.0-1.5', classifier: "android-x86_64"
 
         implementation 'com.google.code.gson:gson:2.8.2'
         annotationProcessor 'org.projectlombok:lombok:1.16.16'
@@ -102,7 +102,7 @@ android {
         }
 
 
-        compile 'com.google.code.findbugs:annotations:3.0.1', {
+        implementation 'com.google.code.findbugs:annotations:3.0.1', {
             exclude module: 'jsr305'
             exclude module: 'jcip-annotations'
         }

--- a/android/DL4JImageRecognitionDemo/build.gradle
+++ b/android/DL4JImageRecognitionDemo/build.gradle
@@ -23,7 +23,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.4.2'
 
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/android/DL4JIrisClassifierDemo/app/build.gradle
+++ b/android/DL4JIrisClassifierDemo/app/build.gradle
@@ -66,45 +66,44 @@ android {
         implementation 'com.android.support:design:27.1.0'
 
 
-        compile (group: 'org.deeplearning4j', name: 'deeplearning4j-core', version: '1.0.0-beta5') {
+        implementation (group: 'org.deeplearning4j', name: 'deeplearning4j-core', version: '1.0.0-beta5') {
             exclude group: 'org.bytedeco', module: 'opencv-platform'
             exclude group: 'org.bytedeco', module: 'leptonica-platform'
             exclude group: 'org.bytedeco', module: 'hdf5-platform'
             exclude group: 'org.nd4j', module: 'nd4j-base64'
         }
-        compile group: 'org.nd4j', name: 'nd4j-native', version: '1.0.0-beta5'
-        compile group: 'org.nd4j', name: 'nd4j-native', version: '1.0.0-beta5', classifier: "android-arm"
-        compile group: 'org.nd4j', name: 'nd4j-native', version: '1.0.0-beta5', classifier: "android-arm64"
-        compile group: 'org.nd4j', name: 'nd4j-native', version: '1.0.0-beta5', classifier: "android-x86"
-        compile group: 'org.nd4j', name: 'nd4j-native', version: '1.0.0-beta5', classifier: "android-x86_64"
-        compile group: 'org.bytedeco', name: 'openblas', version: '0.3.5-1.5'
-        compile group: 'org.bytedeco', name: 'openblas', version: '0.3.5-1.5', classifier: "android-arm"
-        compile group: 'org.bytedeco', name: 'openblas', version: '0.3.5-1.5', classifier: "android-arm64"
-        compile group: 'org.bytedeco', name: 'openblas', version: '0.3.5-1.5', classifier: "android-x86"
-        compile group: 'org.bytedeco', name: 'openblas', version: '0.3.5-1.5', classifier: "android-x86_64"
-        compile group: 'org.bytedeco', name: 'opencv', version: '4.0.1-1.5'
-        compile group: 'org.bytedeco', name: 'opencv', version: '4.0.1-1.5', classifier: "android-arm"
-        compile group: 'org.bytedeco', name: 'opencv', version: '4.0.1-1.5', classifier: "android-arm64"
-        compile group: 'org.bytedeco', name: 'opencv', version: '4.0.1-1.5', classifier: "android-x86"
-        compile group: 'org.bytedeco', name: 'opencv', version: '4.0.1-1.5', classifier: "android-x86_64"
-        compile group: 'org.bytedeco', name: 'leptonica', version: '1.78.0-1.5'
-        compile group: 'org.bytedeco', name: 'leptonica', version: '1.78.0-1.5', classifier: "android-arm"
-        compile group: 'org.bytedeco', name: 'leptonica', version: '1.78.0-1.5', classifier: "android-arm64"
-        compile group: 'org.bytedeco', name: 'leptonica', version: '1.78.0-1.5', classifier: "android-x86"
-        compile group: 'org.bytedeco', name: 'leptonica', version: '1.78.0-1.5', classifier: "android-x86_64"
+        implementation group: 'org.nd4j', name: 'nd4j-native', version: '1.0.0-beta5'
+        implementation group: 'org.nd4j', name: 'nd4j-native', version: '1.0.0-beta5', classifier: "android-arm"
+        implementation group: 'org.nd4j', name: 'nd4j-native', version: '1.0.0-beta5', classifier: "android-arm64"
+        implementation group: 'org.nd4j', name: 'nd4j-native', version: '1.0.0-beta5', classifier: "android-x86"
+        implementation group: 'org.nd4j', name: 'nd4j-native', version: '1.0.0-beta5', classifier: "android-x86_64"
+        implementation group: 'org.bytedeco', name: 'openblas', version: '0.3.5-1.5'
+        implementation group: 'org.bytedeco', name: 'openblas', version: '0.3.5-1.5', classifier: "android-arm"
+        implementation group: 'org.bytedeco', name: 'openblas', version: '0.3.5-1.5', classifier: "android-arm64"
+        implementation group: 'org.bytedeco', name: 'openblas', version: '0.3.5-1.5', classifier: "android-x86"
+        implementation group: 'org.bytedeco', name: 'openblas', version: '0.3.5-1.5', classifier: "android-x86_64"
+        implementation group: 'org.bytedeco', name: 'opencv', version: '4.0.1-1.5'
+        implementation group: 'org.bytedeco', name: 'opencv', version: '4.0.1-1.5', classifier: "android-arm"
+        implementation group: 'org.bytedeco', name: 'opencv', version: '4.0.1-1.5', classifier: "android-arm64"
+        implementation group: 'org.bytedeco', name: 'opencv', version: '4.0.1-1.5', classifier: "android-x86"
+        implementation group: 'org.bytedeco', name: 'opencv', version: '4.0.1-1.5', classifier: "android-x86_64"
+        implementation group: 'org.bytedeco', name: 'leptonica', version: '1.78.0-1.5'
+        implementation group: 'org.bytedeco', name: 'leptonica', version: '1.78.0-1.5', classifier: "android-arm"
+        implementation group: 'org.bytedeco', name: 'leptonica', version: '1.78.0-1.5', classifier: "android-arm64"
+        implementation group: 'org.bytedeco', name: 'leptonica', version: '1.78.0-1.5', classifier: "android-x86"
+        implementation group: 'org.bytedeco', name: 'leptonica', version: '1.78.0-1.5', classifier: "android-x86_64"
 
         implementation 'com.google.code.gson:gson:2.8.2'
         annotationProcessor 'org.projectlombok:lombok:1.16.16'
 
-        implementation 'com.google.code.findbugs:annotations:3.0.1', {
-            exclude module: 'jsr305'
-            exclude module: 'jcip-annotations'
-        }
 
         //This corrects for a junit version conflict.
         configurations.all {
             resolutionStrategy.force 'junit:junit:4.12'
-
+        }
+        compileOptions {
+            sourceCompatibility JavaVersion.VERSION_1_8
+            targetCompatibility JavaVersion.VERSION_1_8
         }
 
     }}

--- a/android/DL4JIrisClassifierDemo/app/src/main/java/org/deeplearning4j/examples/iris_classifier/MainActivity.java
+++ b/android/DL4JIrisClassifierDemo/app/src/main/java/org/deeplearning4j/examples/iris_classifier/MainActivity.java
@@ -180,8 +180,6 @@ public class MainActivity extends AppCompatActivity {
             listBuilder.layer(1, hiddenLayer);
             listBuilder.layer(2, outputLayer);
 
-            listBuilder.backprop(true);
-
             MultiLayerNetwork myNetwork = new MultiLayerNetwork(listBuilder.build());
             myNetwork.init();
 

--- a/android/DL4JIrisClassifierDemo/build.gradle
+++ b/android/DL4JIrisClassifierDemo/build.gradle
@@ -30,7 +30,7 @@ buildscript {
 
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.4.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
Signed-off-by: yptheangel <choowilson93@gmail.com>

## What changes were proposed in this pull request?
project gradle: update gradle version from 3.0.1 to 3.4.2.
app gradle: change "compile" to "implementation" as "compile" is deprecated.

## How was this patch tested?
Tested on a forked repo, https://github.com/yptheangel/dl4j-examples

