### PR TITLE
update netty-buffer version

### DIFF
--- a/dl4j-examples/pom.xml
+++ b/dl4j-examples/pom.xml
@@ -54,6 +54,11 @@
                 <artifactId>netty-common</artifactId>
                 <version>4.1.48.Final</version>
             </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-buffer</artifactId>
+                <version>4.1.48.Final</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
                                                                                 


### PR DESCRIPTION
## What changes were proposed in this pull request?
change netty-buffer version to 4.1.48.Final

## How was this patch tested?

manual tests

## PS
update netty-buffer version to avoid conflicts from datavec-local:1.0.0-beta7

```
+- org.datavec:datavec-local:jar:1.0.0-beta7
   \- org.datavec:datavec-arrow:jar:1.0.0-beta7
      +- org.apache.arrow:arrow-vector:jar:0.11.0
         +- io.netty:netty-buffer:jar:4.1.22.Final
         \- io.netty:netty-common:jar:4.1.22.Final
```