### PR TITLE
Maven duplicated plugin

### DIFF
--- a/data-pipeline-examples/pom.xml
+++ b/data-pipeline-examples/pom.xml
@@ -21,11 +21,11 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.deeplearning4j</groupId>                                       
-    <artifactId>data-pipeline-examples</artifactId>                         
-    <version>1.0.0-beta7</version>                                              
-    <name>Building a data pipeline prior to modeling</name>                                     
-    <description>Loading raw data and processing it before training</description>   
+    <groupId>org.deeplearning4j</groupId>
+    <artifactId>data-pipeline-examples</artifactId>
+    <version>1.0.0-beta7</version>
+    <name>Building a data pipeline prior to modeling</name>
+    <description>Loading raw data and processing it before training</description>
 
     <properties>
         <dl4j-master.version>1.0.0-beta7</dl4j-master.version>
@@ -37,7 +37,7 @@
         <maven.minimum.version>3.3.1</maven.minimum.version>
         <exec-maven-plugin.version>1.4.0</exec-maven-plugin.version>
         <maven-shade-plugin.version>2.4.3</maven-shade-plugin.version>
-        <logback.version>1.1.7</logback.version>                                
+        <logback.version>1.1.7</logback.version>
         <scala.binary.version>2.11</scala.binary.version>
         <spark.version>2.4.3</spark.version>
     </properties>
@@ -102,7 +102,7 @@
 			    <groupId>net.jpountz.lz4</groupId>
 			    <artifactId>lz4</artifactId>
 			  </exclusion>
-			</exclusions> 
+			</exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
@@ -139,59 +139,59 @@
     <!-- Maven Enforcer: Ensures user has an up to date version of Maven before building -->
     <build>
         <plugins>
-            <plugin>                                                            
-                <artifactId>maven-enforcer-plugin</artifactId>                  
-                <version>1.0.1</version>                                        
-                <executions>                                                    
-                    <execution>                                                 
-                        <id>enforce-default</id>                                
-                        <goals>                                                 
-                            <goal>enforce</goal>                                
-                        </goals>                                                
-                        <configuration>                                         
-                            <rules>                                             
-                                <requireMavenVersion>                           
+            <plugin>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>1.0.1</version>
+                <executions>
+                    <execution>
+                        <id>enforce-default</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
                                     <version>[${maven.minimum.version},)</version>
                                     <message>********** Minimum Maven Version is ${maven.minimum.version}. Please upgrade Maven before continuing (run "mvn --version" to check). **********</message>
-                                </requireMavenVersion>                          
-                            </rules>                                            
-                        </configuration>                                        
-                    </execution>                                                
-                </executions>                                                   
-            </plugin>  
+                                </requireMavenVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven-compiler-plugin.version}</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
                 </configuration>
             </plugin>
-            <plugin>                                                            
-                <groupId>com.lewisd</groupId>                                   
-                <artifactId>lint-maven-plugin</artifactId>                      
-                <version>0.0.11</version>                                       
-                <configuration>                                                 
-                    <failOnViolation>true</failOnViolation>                     
-                    <onlyRunRules>                                              
-                        <rule>DuplicateDep</rule>                               
-                        <rule>RedundantPluginVersion</rule>                     
-                        <!-- Rules incompatible with Java 9                     
-                        <rule>VersionProp</rule>                                
-                        <rule>DotVersionProperty</rule> -->                     
-                    </onlyRunRules>                                             
-                </configuration>                                                
-                <executions>                                                    
-                    <execution>                                                 
-                        <id>pom-lint</id>                                       
-                        <phase>validate</phase>                                 
-                        <goals>                                                 
-                            <goal>check</goal>                                  
-                        </goals>                                                
-                    </execution>                                                
-                </executions>                                                   
-            </plugin> 
+            <plugin>
+                <groupId>com.lewisd</groupId>
+                <artifactId>lint-maven-plugin</artifactId>
+                <version>0.0.11</version>
+                <configuration>
+                    <failOnViolation>true</failOnViolation>
+                    <onlyRunRules>
+                        <rule>DuplicateDep</rule>
+                        <rule>RedundantPluginVersion</rule>
+                        <!-- Rules incompatible with Java 9
+                        <rule>VersionProp</rule>
+                        <rule>DotVersionProperty</rule> -->
+                    </onlyRunRules>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>pom-lint</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
@@ -246,43 +246,34 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.5.1</version>
-                <configuration>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
-                </configuration>
-            </plugin>
         </plugins>
-        <pluginManagement>                                                      
-            <plugins>                                                           
-                <plugin>                                                        
-                    <groupId>org.eclipse.m2e</groupId>                          
-                    <artifactId>lifecycle-mapping</artifactId>                  
-                    <version>1.0.0</version>                                    
-                    <configuration>                                             
-                        <lifecycleMappingMetadata>                              
-                            <pluginExecutions>                                  
-                                <pluginExecution>                               
-                                    <pluginExecutionFilter>                     
-                                        <groupId>com.lewisd</groupId>           
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.eclipse.m2e</groupId>
+                    <artifactId>lifecycle-mapping</artifactId>
+                    <version>1.0.0</version>
+                    <configuration>
+                        <lifecycleMappingMetadata>
+                            <pluginExecutions>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>com.lewisd</groupId>
                                         <artifactId>lint-maven-plugin</artifactId>
-                                        <versionRange>[0.0.11,)</versionRange>  
-                                        <goals>                                 
-                                            <goal>check</goal>                  
-                                        </goals>                                
-                                    </pluginExecutionFilter>                    
-                                    <action>                                    
-                                        <ignore/>                               
-                                    </action>                                   
-                                </pluginExecution>                              
-                            </pluginExecutions>                                 
-                        </lifecycleMappingMetadata>                             
-                    </configuration>                                            
-                </plugin>                                                       
-            </plugins>                                                          
-        </pluginManagement>   
+                                        <versionRange>[0.0.11,)</versionRange>
+                                        <goals>
+                                            <goal>check</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <ignore/>
+                                    </action>
+                                </pluginExecution>
+                            </pluginExecutions>
+                        </lifecycleMappingMetadata>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 </project>

--- a/dl4j-examples/pom.xml
+++ b/dl4j-examples/pom.xml
@@ -21,16 +21,16 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.deeplearning4j</groupId>                                       
-    <artifactId>dl4j-examples</artifactId>                         
-    <version>1.0.0-beta7</version>                                              
-    <name>Introduction to DL4J</name>                                     
-    <description>A set of examples introducing the DL4J framework</description>   
+    <groupId>org.deeplearning4j</groupId>
+    <artifactId>dl4j-examples</artifactId>
+    <version>1.0.0-beta7</version>
+    <name>Introduction to DL4J</name>
+    <description>A set of examples introducing the DL4J framework</description>
 
     <properties>
         <dl4j-master.version>1.0.0-beta7</dl4j-master.version>
         <!-- Change the nd4j.backend property to nd4j-cuda-X-platform to use CUDA GPUs -->
-        <!-- <nd4j.backend>nd4j-cuda-10.2-platform</nd4j.backend> -->           
+        <!-- <nd4j.backend>nd4j-cuda-10.2-platform</nd4j.backend> -->
         <nd4j.backend>nd4j-native</nd4j.backend>
         <java.version>1.8</java.version>
         <maven-compiler-plugin.version>3.6.1</maven-compiler-plugin.version>
@@ -56,7 +56,7 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-                                                                                
+
     <dependencies>
         <dependency>
             <groupId>org.nd4j</groupId>
@@ -140,59 +140,59 @@
     <!-- Maven Enforcer: Ensures user has an up to date version of Maven before building -->
     <build>
         <plugins>
-            <plugin>                                                            
-                <artifactId>maven-enforcer-plugin</artifactId>                  
-                <version>1.0.1</version>                                        
-                <executions>                                                    
-                    <execution>                                                 
-                        <id>enforce-default</id>                                
-                        <goals>                                                 
-                            <goal>enforce</goal>                                
-                        </goals>                                                
-                        <configuration>                                         
-                            <rules>                                             
-                                <requireMavenVersion>                           
+            <plugin>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>1.0.1</version>
+                <executions>
+                    <execution>
+                        <id>enforce-default</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
                                     <version>[${maven.minimum.version},)</version>
                                     <message>********** Minimum Maven Version is ${maven.minimum.version}. Please upgrade Maven before continuing (run "mvn --version" to check). **********</message>
-                                </requireMavenVersion>                          
-                            </rules>                                            
-                        </configuration>                                        
-                    </execution>                                                
-                </executions>                                                   
-            </plugin>  
+                                </requireMavenVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven-compiler-plugin.version}</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
                 </configuration>
             </plugin>
-            <plugin>                                                            
-                <groupId>com.lewisd</groupId>                                   
-                <artifactId>lint-maven-plugin</artifactId>                      
-                <version>0.0.11</version>                                       
-                <configuration>                                                 
-                    <failOnViolation>true</failOnViolation>                     
-                    <onlyRunRules>                                              
-                        <rule>DuplicateDep</rule>                               
-                        <rule>RedundantPluginVersion</rule>                     
-                        <!-- Rules incompatible with Java 9                     
-                        <rule>VersionProp</rule>                                
-                        <rule>DotVersionProperty</rule> -->                     
-                    </onlyRunRules>                                             
-                </configuration>                                                
-                <executions>                                                    
-                    <execution>                                                 
-                        <id>pom-lint</id>                                       
-                        <phase>validate</phase>                                 
-                        <goals>                                                 
-                            <goal>check</goal>                                  
-                        </goals>                                                
-                    </execution>                                                
-                </executions>                                                   
-            </plugin> 
+            <plugin>
+                <groupId>com.lewisd</groupId>
+                <artifactId>lint-maven-plugin</artifactId>
+                <version>0.0.11</version>
+                <configuration>
+                    <failOnViolation>true</failOnViolation>
+                    <onlyRunRules>
+                        <rule>DuplicateDep</rule>
+                        <rule>RedundantPluginVersion</rule>
+                        <!-- Rules incompatible with Java 9
+                        <rule>VersionProp</rule>
+                        <rule>DotVersionProperty</rule> -->
+                    </onlyRunRules>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>pom-lint</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
@@ -247,43 +247,34 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.5.1</version>
-                <configuration>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
-                </configuration>
-            </plugin>
         </plugins>
-        <pluginManagement>                                                      
-            <plugins>                                                           
-                <plugin>                                                        
-                    <groupId>org.eclipse.m2e</groupId>                          
-                    <artifactId>lifecycle-mapping</artifactId>                  
-                    <version>1.0.0</version>                                    
-                    <configuration>                                             
-                        <lifecycleMappingMetadata>                              
-                            <pluginExecutions>                                  
-                                <pluginExecution>                               
-                                    <pluginExecutionFilter>                     
-                                        <groupId>com.lewisd</groupId>           
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.eclipse.m2e</groupId>
+                    <artifactId>lifecycle-mapping</artifactId>
+                    <version>1.0.0</version>
+                    <configuration>
+                        <lifecycleMappingMetadata>
+                            <pluginExecutions>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>com.lewisd</groupId>
                                         <artifactId>lint-maven-plugin</artifactId>
-                                        <versionRange>[0.0.11,)</versionRange>  
-                                        <goals>                                 
-                                            <goal>check</goal>                  
-                                        </goals>                                
-                                    </pluginExecutionFilter>                    
-                                    <action>                                    
-                                        <ignore/>                               
-                                    </action>                                   
-                                </pluginExecution>                              
-                            </pluginExecutions>                                 
-                        </lifecycleMappingMetadata>                             
-                    </configuration>                                            
-                </plugin>                                                       
-            </plugins>                                                          
-        </pluginManagement>   
+                                        <versionRange>[0.0.11,)</versionRange>
+                                        <goals>
+                                            <goal>check</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <ignore/>
+                                    </action>
+                                </pluginExecution>
+                            </pluginExecutions>
+                        </lifecycleMappingMetadata>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 </project>

--- a/nd4j-ndarray-examples/pom.xml
+++ b/nd4j-ndarray-examples/pom.xml
@@ -21,134 +21,125 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.deeplearning4j</groupId>                                       
-    <artifactId>nd4j-ndarray-examples</artifactId>                         
-    <version>1.0.0-beta7</version>                                              
-    <name>ND4J Examples operating on ndarrays</name>                                     
-    <description>Working with NDArrays</description>   
+    <groupId>org.deeplearning4j</groupId>
+    <artifactId>nd4j-ndarray-examples</artifactId>
+    <version>1.0.0-beta7</version>
+    <name>ND4J Examples operating on ndarrays</name>
+    <description>Working with NDArrays</description>
 
     <properties>
         <dl4j-master.version>1.0.0-beta7</dl4j-master.version>
         <!-- Change the nd4j.backend property to nd4j-cuda-X-platform to use CUDA GPUs -->
-        <!-- <nd4j.backend>nd4j-cuda-10.2-platform</nd4j.backend> -->           
+        <!-- <nd4j.backend>nd4j-cuda-10.2-platform</nd4j.backend> -->
         <nd4j.backend>nd4j-native</nd4j.backend>
         <java.version>1.8</java.version>
         <maven-compiler-plugin.version>3.6.1</maven-compiler-plugin.version>
         <maven.minimum.version>3.3.1</maven.minimum.version>
-        <logback.version>1.1.7</logback.version>                                
+        <logback.version>1.1.7</logback.version>
     </properties>
-                                                                                
-    <dependencies>                                                              
-        <dependency>                                                            
-            <groupId>org.nd4j</groupId>                                         
-            <artifactId>${nd4j.backend}</artifactId>                            
-            <version>${dl4j-master.version}</version>                           
-        </dependency>                                                           
-        <dependency>                                                            
-            <groupId>ch.qos.logback</groupId>                                   
-            <artifactId>logback-classic</artifactId>                            
-            <version>${logback.version}</version>                               
+
+    <dependencies>
+        <dependency>
+            <groupId>org.nd4j</groupId>
+            <artifactId>${nd4j.backend}</artifactId>
+            <version>${dl4j-master.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${logback.version}</version>
         </dependency>
         <dependency>
             <groupId>org.deeplearning4j</groupId>
             <artifactId>deeplearning4j-utility-iterators</artifactId>
             <version>${dl4j-master.version}</version>
         </dependency>
-    </dependencies> 
+    </dependencies>
 
     <!-- Maven Enforcer: Ensures user has an up to date version of Maven before building -->
     <build>
         <plugins>
-            <plugin>                                                            
-                <artifactId>maven-enforcer-plugin</artifactId>                  
-                <version>1.0.1</version>                                        
-                <executions>                                                    
-                    <execution>                                                 
-                        <id>enforce-default</id>                                
-                        <goals>                                                 
-                            <goal>enforce</goal>                                
-                        </goals>                                                
-                        <configuration>                                         
-                            <rules>                                             
-                                <requireMavenVersion>                           
+            <plugin>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>1.0.1</version>
+                <executions>
+                    <execution>
+                        <id>enforce-default</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
                                     <version>[${maven.minimum.version},)</version>
                                     <message>********** Minimum Maven Version is ${maven.minimum.version}. Please upgrade Maven before continuing (run "mvn --version" to check). **********</message>
-                                </requireMavenVersion>                          
-                            </rules>                                            
-                        </configuration>                                        
-                    </execution>                                                
-                </executions>                                                   
-            </plugin>  
+                                </requireMavenVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven-compiler-plugin.version}</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
-            </plugin>
-            <plugin>                                                            
-                <groupId>com.lewisd</groupId>                                   
-                <artifactId>lint-maven-plugin</artifactId>                      
-                <version>0.0.11</version>                                       
-                <configuration>                                                 
-                    <failOnViolation>true</failOnViolation>                     
-                    <onlyRunRules>                                              
-                        <rule>DuplicateDep</rule>                               
-                        <rule>RedundantPluginVersion</rule>                     
-                        <!-- Rules incompatible with Java 9                     
-                        <rule>VersionProp</rule>                                
-                        <rule>DotVersionProperty</rule> -->                     
-                    </onlyRunRules>                                             
-                </configuration>                                                
-                <executions>                                                    
-                    <execution>                                                 
-                        <id>pom-lint</id>                                       
-                        <phase>validate</phase>                                 
-                        <goals>                                                 
-                            <goal>check</goal>                                  
-                        </goals>                                                
-                    </execution>                                                
-                </executions>                                                   
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.5.1</version>
-                <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>com.lewisd</groupId>
+                <artifactId>lint-maven-plugin</artifactId>
+                <version>0.0.11</version>
+                <configuration>
+                    <failOnViolation>true</failOnViolation>
+                    <onlyRunRules>
+                        <rule>DuplicateDep</rule>
+                        <rule>RedundantPluginVersion</rule>
+                        <!-- Rules incompatible with Java 9
+                        <rule>VersionProp</rule>
+                        <rule>DotVersionProperty</rule> -->
+                    </onlyRunRules>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>pom-lint</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
-        <pluginManagement>                                                      
-            <plugins>                                                           
-                <plugin>                                                        
-                    <groupId>org.eclipse.m2e</groupId>                          
-                    <artifactId>lifecycle-mapping</artifactId>                  
-                    <version>1.0.0</version>                                    
-                    <configuration>                                             
-                        <lifecycleMappingMetadata>                              
-                            <pluginExecutions>                                  
-                                <pluginExecution>                               
-                                    <pluginExecutionFilter>                     
-                                        <groupId>com.lewisd</groupId>           
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.eclipse.m2e</groupId>
+                    <artifactId>lifecycle-mapping</artifactId>
+                    <version>1.0.0</version>
+                    <configuration>
+                        <lifecycleMappingMetadata>
+                            <pluginExecutions>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>com.lewisd</groupId>
                                         <artifactId>lint-maven-plugin</artifactId>
-                                        <versionRange>[0.0.11,)</versionRange>  
-                                        <goals>                                 
-                                            <goal>check</goal>                  
-                                        </goals>                                
-                                    </pluginExecutionFilter>                    
-                                    <action>                                    
-                                        <ignore/>                               
-                                    </action>                                   
-                                </pluginExecution>                              
-                            </pluginExecutions>                                 
-                        </lifecycleMappingMetadata>                             
-                    </configuration>                                            
-                </plugin>                                                       
-            </plugins>                                                          
+                                        <versionRange>[0.0.11,)</versionRange>
+                                        <goals>
+                                            <goal>check</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <ignore/>
+                                    </action>
+                                </pluginExecution>
+                            </pluginExecutions>
+                        </lifecycleMappingMetadata>
+                    </configuration>
+                </plugin>
+            </plugins>
         </pluginManagement>
     </build>
 </project>

--- a/rl4j-examples/pom.xml
+++ b/rl4j-examples/pom.xml
@@ -85,8 +85,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven-compiler-plugin.version}</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -112,15 +112,6 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.5.1</version>
-                <configuration>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
-                </configuration>
             </plugin>
         </plugins>
         <pluginManagement>

--- a/samediff-examples/pom.xml
+++ b/samediff-examples/pom.xml
@@ -21,16 +21,16 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.deeplearning4j</groupId>                                       
+    <groupId>org.deeplearning4j</groupId>
     <artifactId>samediff-examples</artifactId>
-    <version>1.0.0-beta7</version>                                              
-    <name>Quickstart to SameDiff</name>                                     
-    <description>A set of beginner examples introducing the SameDiff framework</description>   
+    <version>1.0.0-beta7</version>
+    <name>Quickstart to SameDiff</name>
+    <description>A set of beginner examples introducing the SameDiff framework</description>
 
     <properties>
         <dl4j-master.version>1.0.0-beta7</dl4j-master.version>
         <!-- Change the nd4j.backend property to nd4j-cuda-X-platform to use CUDA GPUs -->
-        <!-- <nd4j.backend>nd4j-cuda-10.2-platform</nd4j.backend> -->           
+        <!-- <nd4j.backend>nd4j-cuda-10.2-platform</nd4j.backend> -->
         <nd4j.backend>nd4j-native</nd4j.backend>
         <java.version>1.8</java.version>
         <maven-compiler-plugin.version>3.6.1</maven-compiler-plugin.version>
@@ -57,7 +57,7 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-                                                                                
+
     <dependencies>
         <dependency>
             <groupId>org.nd4j</groupId>
@@ -121,59 +121,59 @@
     <!-- Maven Enforcer: Ensures user has an up to date version of Maven before building -->
     <build>
         <plugins>
-            <plugin>                                                            
-                <artifactId>maven-enforcer-plugin</artifactId>                  
-                <version>1.0.1</version>                                        
-                <executions>                                                    
-                    <execution>                                                 
-                        <id>enforce-default</id>                                
-                        <goals>                                                 
-                            <goal>enforce</goal>                                
-                        </goals>                                                
-                        <configuration>                                         
-                            <rules>                                             
-                                <requireMavenVersion>                           
+            <plugin>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>1.0.1</version>
+                <executions>
+                    <execution>
+                        <id>enforce-default</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
                                     <version>[${maven.minimum.version},)</version>
                                     <message>********** Minimum Maven Version is ${maven.minimum.version}. Please upgrade Maven before continuing (run "mvn --version" to check). **********</message>
-                                </requireMavenVersion>                          
-                            </rules>                                            
-                        </configuration>                                        
-                    </execution>                                                
-                </executions>                                                   
-            </plugin>  
+                                </requireMavenVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven-compiler-plugin.version}</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
                 </configuration>
             </plugin>
-            <plugin>                                                            
-                <groupId>com.lewisd</groupId>                                   
-                <artifactId>lint-maven-plugin</artifactId>                      
-                <version>0.0.11</version>                                       
-                <configuration>                                                 
-                    <failOnViolation>true</failOnViolation>                     
-                    <onlyRunRules>                                              
-                        <rule>DuplicateDep</rule>                               
-                        <rule>RedundantPluginVersion</rule>                     
-                        <!-- Rules incompatible with Java 9                     
-                        <rule>VersionProp</rule>                                
-                        <rule>DotVersionProperty</rule> -->                     
-                    </onlyRunRules>                                             
-                </configuration>                                                
-                <executions>                                                    
-                    <execution>                                                 
-                        <id>pom-lint</id>                                       
-                        <phase>validate</phase>                                 
-                        <goals>                                                 
-                            <goal>check</goal>                                  
-                        </goals>                                                
-                    </execution>                                                
-                </executions>                                                   
-            </plugin> 
+            <plugin>
+                <groupId>com.lewisd</groupId>
+                <artifactId>lint-maven-plugin</artifactId>
+                <version>0.0.11</version>
+                <configuration>
+                    <failOnViolation>true</failOnViolation>
+                    <onlyRunRules>
+                        <rule>DuplicateDep</rule>
+                        <rule>RedundantPluginVersion</rule>
+                        <!-- Rules incompatible with Java 9
+                        <rule>VersionProp</rule>
+                        <rule>DotVersionProperty</rule> -->
+                    </onlyRunRules>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>pom-lint</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
@@ -228,43 +228,34 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.5.1</version>
-                <configuration>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
-                </configuration>
-            </plugin>
         </plugins>
-        <pluginManagement>                                                      
-            <plugins>                                                           
-                <plugin>                                                        
-                    <groupId>org.eclipse.m2e</groupId>                          
-                    <artifactId>lifecycle-mapping</artifactId>                  
-                    <version>1.0.0</version>                                    
-                    <configuration>                                             
-                        <lifecycleMappingMetadata>                              
-                            <pluginExecutions>                                  
-                                <pluginExecution>                               
-                                    <pluginExecutionFilter>                     
-                                        <groupId>com.lewisd</groupId>           
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.eclipse.m2e</groupId>
+                    <artifactId>lifecycle-mapping</artifactId>
+                    <version>1.0.0</version>
+                    <configuration>
+                        <lifecycleMappingMetadata>
+                            <pluginExecutions>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>com.lewisd</groupId>
                                         <artifactId>lint-maven-plugin</artifactId>
-                                        <versionRange>[0.0.11,)</versionRange>  
-                                        <goals>                                 
-                                            <goal>check</goal>                  
-                                        </goals>                                
-                                    </pluginExecutionFilter>                    
-                                    <action>                                    
-                                        <ignore/>                               
-                                    </action>                                   
-                                </pluginExecution>                              
-                            </pluginExecutions>                                 
-                        </lifecycleMappingMetadata>                             
-                    </configuration>                                            
-                </plugin>                                                       
-            </plugins>                                                          
-        </pluginManagement>   
+                                        <versionRange>[0.0.11,)</versionRange>
+                                        <goals>
+                                            <goal>check</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <ignore/>
+                                    </action>
+                                </pluginExecution>
+                            </pluginExecutions>
+                        </lifecycleMappingMetadata>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 </project>

--- a/tensorflow-keras-import-examples/pom.xml
+++ b/tensorflow-keras-import-examples/pom.xml
@@ -21,27 +21,27 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.deeplearning4j</groupId>                                       
-    <artifactId>model-import-examples</artifactId>                         
-    <version>1.0.0-beta7</version>                                              
-    <name>model import examples</name>                                     
-    <description>Loading models trained in keras or tensorflow</description>   
+    <groupId>org.deeplearning4j</groupId>
+    <artifactId>model-import-examples</artifactId>
+    <version>1.0.0-beta7</version>
+    <name>model import examples</name>
+    <description>Loading models trained in keras or tensorflow</description>
 
     <properties>
         <dl4j-master.version>1.0.0-beta7</dl4j-master.version>
         <!-- Change the nd4j.backend property to nd4j-cuda-X-platform to use CUDA GPUs -->
         <nd4j.backend>nd4j-native</nd4j.backend>
-        <!-- <nd4j.backend>nd4j-cuda-10.2-platform</nd4j.backend> -->           
+        <!-- <nd4j.backend>nd4j-cuda-10.2-platform</nd4j.backend> -->
         <java.version>1.8</java.version>
         <maven-compiler-plugin.version>3.6.1</maven-compiler-plugin.version>
         <maven.minimum.version>3.3.1</maven.minimum.version>
         <exec-maven-plugin.version>1.4.0</exec-maven-plugin.version>
         <maven-shade-plugin.version>2.4.3</maven-shade-plugin.version>
-        <logback.version>1.1.7</logback.version>                                
+        <logback.version>1.1.7</logback.version>
         <javacpp.version>1.5.2</javacpp.version>
         <tensorflow.version>1.15.0</tensorflow.version>
     </properties>
-                                                                                
+
     <dependencies>
         <dependency>
             <groupId>org.nd4j</groupId>
@@ -83,59 +83,59 @@
     <!-- Maven Enforcer: Ensures user has an up to date version of Maven before building -->
     <build>
         <plugins>
-            <plugin>                                                            
-                <artifactId>maven-enforcer-plugin</artifactId>                  
-                <version>1.0.1</version>                                        
-                <executions>                                                    
-                    <execution>                                                 
-                        <id>enforce-default</id>                                
-                        <goals>                                                 
-                            <goal>enforce</goal>                                
-                        </goals>                                                
-                        <configuration>                                         
-                            <rules>                                             
-                                <requireMavenVersion>                           
+            <plugin>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>1.0.1</version>
+                <executions>
+                    <execution>
+                        <id>enforce-default</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
                                     <version>[${maven.minimum.version},)</version>
                                     <message>********** Minimum Maven Version is ${maven.minimum.version}. Please upgrade Maven before continuing (run "mvn --version" to check). **********</message>
-                                </requireMavenVersion>                          
-                            </rules>                                            
-                        </configuration>                                        
-                    </execution>                                                
-                </executions>                                                   
-            </plugin>  
+                                </requireMavenVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven-compiler-plugin.version}</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
                 </configuration>
             </plugin>
-            <plugin>                                                            
-                <groupId>com.lewisd</groupId>                                   
-                <artifactId>lint-maven-plugin</artifactId>                      
-                <version>0.0.11</version>                                       
-                <configuration>                                                 
-                    <failOnViolation>true</failOnViolation>                     
-                    <onlyRunRules>                                              
-                        <rule>DuplicateDep</rule>                               
-                        <rule>RedundantPluginVersion</rule>                     
-                        <!-- Rules incompatible with Java 9                     
-                        <rule>VersionProp</rule>                                
-                        <rule>DotVersionProperty</rule> -->                     
-                    </onlyRunRules>                                             
-                </configuration>                                                
-                <executions>                                                    
-                    <execution>                                                 
-                        <id>pom-lint</id>                                       
-                        <phase>validate</phase>                                 
-                        <goals>                                                 
-                            <goal>check</goal>                                  
-                        </goals>                                                
-                    </execution>                                                
-                </executions>                                                   
-            </plugin> 
+            <plugin>
+                <groupId>com.lewisd</groupId>
+                <artifactId>lint-maven-plugin</artifactId>
+                <version>0.0.11</version>
+                <configuration>
+                    <failOnViolation>true</failOnViolation>
+                    <onlyRunRules>
+                        <rule>DuplicateDep</rule>
+                        <rule>RedundantPluginVersion</rule>
+                        <!-- Rules incompatible with Java 9
+                        <rule>VersionProp</rule>
+                        <rule>DotVersionProperty</rule> -->
+                    </onlyRunRules>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>pom-lint</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
@@ -190,43 +190,34 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.5.1</version>
-                <configuration>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
-                </configuration>
-            </plugin>
         </plugins>
-        <pluginManagement>                                                      
-            <plugins>                                                           
-                <plugin>                                                        
-                    <groupId>org.eclipse.m2e</groupId>                          
-                    <artifactId>lifecycle-mapping</artifactId>                  
-                    <version>1.0.0</version>                                    
-                    <configuration>                                             
-                        <lifecycleMappingMetadata>                              
-                            <pluginExecutions>                                  
-                                <pluginExecution>                               
-                                    <pluginExecutionFilter>                     
-                                        <groupId>com.lewisd</groupId>           
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.eclipse.m2e</groupId>
+                    <artifactId>lifecycle-mapping</artifactId>
+                    <version>1.0.0</version>
+                    <configuration>
+                        <lifecycleMappingMetadata>
+                            <pluginExecutions>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>com.lewisd</groupId>
                                         <artifactId>lint-maven-plugin</artifactId>
-                                        <versionRange>[0.0.11,)</versionRange>  
-                                        <goals>                                 
-                                            <goal>check</goal>                  
-                                        </goals>                                
-                                    </pluginExecutionFilter>                    
-                                    <action>                                    
-                                        <ignore/>                               
-                                    </action>                                   
-                                </pluginExecution>                              
-                            </pluginExecutions>                                 
-                        </lifecycleMappingMetadata>                             
-                    </configuration>                                            
-                </plugin>                                                       
-            </plugins>                                                          
-        </pluginManagement>   
+                                        <versionRange>[0.0.11,)</versionRange>
+                                        <goals>
+                                            <goal>check</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <ignore/>
+                                    </action>
+                                </pluginExecution>
+                            </pluginExecutions>
+                        </lifecycleMappingMetadata>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 </project>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Removed duplicated plugin declaration (maven-compiler-plugin) in pom files.

## How was this patch tested?

Build all packages after changes.

Please review
https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md before opening a pull request.
