### PR TITLE
Fix MNISTAutoencoder: switch output layer to LEAKYRELU

### DIFF
--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/quickstart/modeling/feedforward/unsupervised/MNISTAutoencoder.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/quickstart/modeling/feedforward/unsupervised/MNISTAutoencoder.java
@@ -74,6 +74,7 @@ public class MNISTAutoencoder {
                 .layer(new DenseLayer.Builder().nIn(10).nOut(250)
                         .build())
                 .layer(new OutputLayer.Builder().nIn(250).nOut(784)
+                        .activation(Activation.LEAKYRELU)
                         .lossFunction(LossFunctions.LossFunction.MSE)
                         .build())
                 .build();


### PR DESCRIPTION
SOFTMAX default does not work with autoencoders.

## What changes were proposed in this pull request?

Fix broken MNISTAutoencoder example.

## How was this patch tested?

Visually tested.

Please review
https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md before opening a pull request.
