### PR TITLE
Add README and comments for feedforward classification examples

### DIFF
--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/quickstart/modeling/feedforward/classification/MNISTSingleLayer.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/quickstart/modeling/feedforward/classification/MNISTSingleLayer.java
@@ -17,6 +17,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
+
+   // MNISTSingleLayer.java
+  // Simple single-hidden-layer MLP for MNIST digit classification.
+ // Demonstrates basic feedforward networks in DL4J.
+
 package org.deeplearning4j.examples.quickstart.modeling.feedforward.classification;
 
 import org.deeplearning4j.datasets.iterator.impl.MnistDataSetIterator;
@@ -72,6 +77,9 @@ public class MNISTSingleLayer {
 
 
         log.info("Build model....");
+
+        // Build a single-hidden-layer MLP for MNIST (28x28 images flattened to 784 inputs)
+
         MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
                 .seed(rngSeed) //include a random seed for reproducibility
                 // use stochastic gradient descent as an optimization algorithm
@@ -100,6 +108,7 @@ public class MNISTSingleLayer {
         log.info("Train model....");
         model.fit(mnistTrain, numEpochs);
 
+         // Evaluate the model on the MNIST test dataset
 
         log.info("Evaluate model....");
         Evaluation eval = model.evaluate(mnistTest);

--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/quickstart/modeling/feedforward/classification/ModelXOR.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/quickstart/modeling/feedforward/classification/ModelXOR.java
@@ -17,6 +17,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
+
+  // ModelXOR.java
+ // Demonstrates solving the XOR problem using a small MLP.
+// XOR is not linearly separable -> requires hidden layers.
+
 package org.deeplearning4j.examples.quickstart.modeling.feedforward.classification;
 
 import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
@@ -109,6 +114,9 @@ public class ModelXOR {
         DataSet ds = new DataSet(input, labels);
 
         log.info("Network configuration and training...");
+
+        // Build a small 2-layer MLP for XOR classification
+
 
         MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
             .updater(new Sgd(0.1))

--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/quickstart/modeling/feedforward/classification/README.md
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/quickstart/modeling/feedforward/classification/README.md
@@ -1,0 +1,84 @@
+# Feedforward Neural Network Classification Examples – DeepLearning4J
+
+This folder contains several feedforward neural network (MLP) classification examples using DeepLearning4J.  
+They demonstrate how to train neural networks on classic datasets such as MNIST, Iris, XOR, and synthetic datasets.
+
+---
+
+## 🧠 MNISTSingleLayer.java
+A simple single-hidden-layer MLP for MNIST digit classification.
+
+### What this example shows
+- Loading MNIST data
+- Building a minimal feedforward model
+- Backpropagation training
+- Evaluating test accuracy
+
+---
+
+## 🧠 MNISTDoubleLayer.java
+A deeper MLP with two hidden layers for MNIST.
+
+### Why it's useful
+- Shows the impact of depth on accuracy
+- Good introduction to multi-layer feedforward networks
+
+---
+
+## 🌸 IrisClassifier.java
+A classifier for the Iris flower dataset.
+
+### What you learn
+- Basic classification with a very small dataset
+- How to use evaluation metrics
+- Simple preprocessing
+
+---
+
+## 🧪 ModelXOR.java
+A classic MLP solving the XOR problem.
+
+### Why XOR?
+- Not linearly separable
+- Demonstrates why deep networks are needed
+
+---
+
+## 🌙 MoonClassifier.java
+Binary classification on a synthetic two-moon dataset.
+
+### Learnings
+- Handling noisy 2D datasets
+- Visualizing classification boundaries
+
+---
+
+## 🪐 SaturnClassifier.java
+Classification of Saturn (concentric circles) synthetic dataset.
+
+### Shows
+- Decision boundaries
+- How MLPs learn non-linear patterns
+
+---
+
+## ✔ How to Run Any Example
+
+Use the following command template:
+
+
+mvn -q exec:java -Dexec.mainClass="org.deeplearning4j.examples.quickstart.modeling.feedforward.classification.<ClassName>"
+
+
+Example:
+
+
+
+mvn -q exec:java -Dexec.mainClass="org.deeplearning4j.examples.quickstart.modeling.feedforward.classification.MNISTSingleLayer"
+
+
+---
+
+## 🙌 Why This README Helps
+These classification examples previously had no documentation.  
+This README improves clarity, explains datasets, and helps beginners understand each example.


### PR DESCRIPTION
### Summary
Added documentation and comments for feedforward MLP classification examples.

### Changes
- Added README.md explaining datasets and examples
- Added top-level and inline comments to MNISTSingleLayer and ModelXOR

### Why
These examples lacked documentation. This PR improves clarity for beginners and contributors.
